### PR TITLE
Improvements

### DIFF
--- a/.github/workflows/build-and-upload.yaml
+++ b/.github/workflows/build-and-upload.yaml
@@ -24,14 +24,14 @@ jobs:
       url: https://pypi.org/p/dibber
 
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: "3.13"
 
-      - uses: astral-sh/setup-uv@557e51de59eb14aaaba2ed9621916900a91d50c6 # v6.6.1
+      - uses: astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41 # v7.1.2
 
       - name: Update package version
         run: |

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -12,9 +12,9 @@ jobs:
       # added or changed files to the repository.
       contents: write
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6
+      - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: "3.13"
 
@@ -22,5 +22,5 @@ jobs:
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
 
       # Commit all changed files back to the repository
-      - uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0 # v6.0.1
+      - uses: stefanzweifel/git-auto-commit-action@28e16e81777b558cc906c8750092100bbb34c5e3 # v7.0.0
         if: always()

--- a/dibber/images.py
+++ b/dibber/images.py
@@ -3,7 +3,7 @@ import sys
 import time
 from datetime import timedelta
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, NamedTuple
 
 import humanize
 from loguru import logger
@@ -178,13 +178,19 @@ def create_manifest(image: str, digests: list[str]):
     )
 
 
+class BuildResults(NamedTuple):
+    tag_map: list[str]
+    contexts: str
+    uniq_id: str
+
+
 def build_image(
     image: str,
     version: str,
     platform: str,
     contexts: list[str] = [],
     local_only=True,
-) -> (str, str):
+) -> BuildResults:
     start = time.perf_counter()
 
     # Need a temporary ID due to limitations of buildx
@@ -279,7 +285,9 @@ def build_image(
         elapsed=humanize.precisedelta(timedelta(seconds=elapsed)),
     )
 
-    return tag_map, f"{local_with_tag} {repo_with_uniq_id}", repo_with_uniq_id
+    return BuildResults(
+        tag_map, f"{local_with_tag} {repo_with_uniq_id}", repo_with_uniq_id
+    )
 
 
 def docker_image(image: str) -> str:

--- a/dibber/images.py
+++ b/dibber/images.py
@@ -277,13 +277,22 @@ def build_image(
     elapsed = time.perf_counter() - start
     sha256_summary = sha256[:13] + "..." + sha256[-5:]
 
-    logger.info(
-        "Built and uploaded {name} as {repo_with_uniq_id} ({sha256}) in {elapsed}",
-        name=dockerfile_path,
-        repo_with_uniq_id=repo_with_uniq_id,
-        sha256=sha256_summary,
-        elapsed=humanize.precisedelta(timedelta(seconds=elapsed)),
-    )
+    if local_only:
+        logger.info(
+            "Built {name} as {local_with_tag} ({sha256}) in {elapsed}",
+            name=dockerfile_path,
+            local_with_tag=local_with_tag,
+            sha256=sha256_summary,
+            elapsed=humanize.precisedelta(timedelta(seconds=elapsed)),
+        )
+    else:
+        logger.info(
+            "Built and uploaded {name} as {repo_with_uniq_id} ({sha256}) in {elapsed}",
+            name=dockerfile_path,
+            repo_with_uniq_id=repo_with_uniq_id,
+            sha256=sha256_summary,
+            elapsed=humanize.precisedelta(timedelta(seconds=elapsed)),
+        )
 
     return BuildResults(
         tag_map, f"{local_with_tag} {repo_with_uniq_id}", repo_with_uniq_id

--- a/dibber/main.py
+++ b/dibber/main.py
@@ -42,9 +42,9 @@ def _build_images(pool, images, platform, contexts, local_only):
             new_contexts = []
             new_tag_map = []
             for result in results:
-                new_tag_map += result[0]
-                new_contexts.append(result[1])
-                uniq_ids.append(result[2])
+                new_tag_map += result.tag_map
+                new_contexts.append(result.contexts)
+                uniq_ids.append(result.uniq_id)
             return new_tag_map, new_contexts, uniq_ids
             break
         except multiprocessing.context.TimeoutError:

--- a/dibber/main.py
+++ b/dibber/main.py
@@ -122,8 +122,6 @@ def _build_all_images(parallel: int, platform: str, local_only: bool = False):
                     pool.terminate()
                     raise
 
-            pool.close()
-
     # Write the contexts for the multi-arch image stitching
     write_manifest_information(tag_maps, uniq_ids)
 

--- a/dibber/main.py
+++ b/dibber/main.py
@@ -161,6 +161,9 @@ def build(parallel: int, platform: Optional[str] = None, local_only: bool = Fals
             machine = "amd64"
         if machine == "aarch64":
             machine = "arm64"
+        if os == "darwin":
+            # On Mac we want to typically build linux containers
+            os = "linux"
         platform = f"{os}/{machine}"
 
     _build_all_images(parallel, platform, local_only)


### PR DESCRIPTION
- Remove unnecessary `pool.close()` (handled by the context manager, i.e. `with` block)
- By default build linux images on Mac (darwin unlikely supported)
- Fix type annotation + refactoring
- Improve logging when building locally
- Update GitHub actions